### PR TITLE
Changed opnsenseWGName character requirements

### DIFF
--- a/PIAWireguard.py
+++ b/PIAWireguard.py
@@ -213,8 +213,9 @@ if config['piaUseDip'] != True and config['piaUseDip'] != False:
     print("piaUseDip can only be true or false")
     sys.exit(0)
 
-if config['opnsenseWGName'] == '' or not re.search("^[a-zA-Z0-9]*$", config['opnsenseWGName']):
-    print("Please define opnsenseWGName variable with the correct value in the json file. Allowed characters are 0-9, a-z, and A-Z")
+if config['opnsenseWGName'] == '' or not re.search("^([0-9a-zA-Z._\-]){1,64}$", config['opnsenseWGName']):
+    print("Please define opnsenseWGName variable with the correct value in the json file. " +
+    "Should be a string between 1 and 64 characters. Allowed characters are alphanumeric characters, dash and underscores.")
     sys.exit(0)
 
 opnsenseURL = config['opnsenseURL']


### PR DESCRIPTION
Added a character length requirement and allowed dashes and underscores. This is in line with the validation done by the OPNsense gui, see [here](https://github.com/opnsense/plugins/blob/86135ce2820387898e6c582b45eb75b5cb1a36a6/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml#L15), and updated the error text.

I tested this on a working configuration, using the following code:

```py
import re
import json

config = json.loads(open("./PIAWireguard.json", 'r').read())

if config['opnsenseWGName'] == '' or not re.search("^([0-9a-zA-Z._\-]){1,64}$", config['opnsenseWGName']):
    print("Please define opnsenseWGName variable with the correct value in the json file. " +
    "Should be a string between 1 and 64 characters. Allowed characters are alphanumeric characters, dash and underscores.")
```
Using the following strings:

Valid strings (expected passes)
- "PIA" (Pass)
- "PIA_VPN" (Pass)
- "This_is_a_64_character_string_6E1A20416ACF569F929AD751197BA2DW1G" (Pass)

Invalid strings (expected failures)
- "PI A" (failed)
- " PIA" (failed)
- "PIA " (failed)
- "$PIA" (failed)
- "This_is_a_65_character_string_6E1A20416ACF569F929AD751197BA2DWG1Z" (failed)

I really appreciate you making and maintaining this very useful script.
Thanks!
Chase
