### PR TITLE
Implement Key Pair Generation Calls

### DIFF
--- a/PIAWireguard.py
+++ b/PIAWireguard.py
@@ -243,10 +243,23 @@ for instance in wireguardInstances:
 
 # if the PIA WG instance doesn't exist we'll create it.
 if opnsenseWGUUID == '':
+    # Generate a key pair for the server
+    r = requests.get(f'{opnsenseURL}/api/wireguard/server/keyPair/', auth=(config['opnsenseKey'], config['opnsenseSecret']), verify=urlVerify)
+    if r.status_code != 200:
+        print("keyPair request filed non 200 status code - trying to generate wireGuard key pair")
+        sys.exit(2)
+
+    keyPair = json.loads(r.text)
+    if keyPair['status'] != "ok":
+        print("keyPair response non ok status - trying to generate wireGuard key pair")
+        sys.exit(2)
+
     createObject = {
         "server": {
             "enabled": '1',
             "name": config['opnsenseWGName'],
+            "pubkey": keyPair['pubkey'],
+            "privkey": keyPair['privkey'],
             "port": config['opnsenseWGPort'],
             "tunneladdress": opnsenseWGIP,
             "disableroutes": '1',


### PR DESCRIPTION
Version 2.0_2 of os-wireguard includes changes to the server schema to require the key pair fields (`pubkey` and `privkey`) be provided at the time of server creation instead of automatically generating them as it did previously.

This PR implements the new `/api/wireguard/server/keyPair/` endpoint to generate a key pair and provide the values to the `addServer` request. This resolves an error returned by the `addKey` request due to `opnsenseWGPubkey` being an empty string when `addServer` silently failed.

Schema / behaviour changes can be found here: https://github.com/opnsense/plugins/commit/15a3559d58a057d00b2e21c694ca727c1d81f8d8.