### PR TITLE
Update System CAs path

### DIFF
--- a/PIAWireguard.py
+++ b/PIAWireguard.py
@@ -38,17 +38,6 @@ import secrets
 # Please see PIAWireguard.json for configuration settings
 #
 
-# Determine the correct CA bundle path
-if os.path.isfile("/etc/ssl/cert.pem"):
-    ca_bundle = "/etc/ssl/cert.pem"  # Path for older systems
-elif os.path.isfile("/usr/local/share/certs/ca-root-nss.crt"):
-    ca_bundle = "/usr/local/share/certs/ca-root-nss.crt"  # Path for updated systems
-else:
-    raise FileNotFoundError(
-        "No valid CA certificate bundle found. Please ensure your system has a CA bundle at either "
-        "/etc/ssl/cert.pem or /usr/local/share/certs/ca-root-nss.crt"
-    )
-
 #
 # Script Start
 #
@@ -494,7 +483,7 @@ for instance_obj in instances_array:
             "Authorization": f"Token {piaToken}",
             "content-type": "application/json"
         }
-        dipSession = CreateRequestsSession(None, piaAuthHeaders, ca_bundle)
+        dipSession = CreateRequestsSession(None, piaAuthHeaders, "/usr/local/share/certs/ca-root-nss.crt")
         break # Only need one set of details
 
 # Now we process each instance that needs the server changing

--- a/PIAWireguard.py
+++ b/PIAWireguard.py
@@ -38,6 +38,16 @@ import secrets
 # Please see PIAWireguard.json for configuration settings
 #
 
+# Determine the correct CA bundle path
+if os.path.isfile("/etc/ssl/cert.pem"):
+    ca_bundle = "/etc/ssl/cert.pem"  # Path for older systems
+elif os.path.isfile("/usr/local/share/certs/ca-root-nss.crt"):
+    ca_bundle = "/usr/local/share/certs/ca-root-nss.crt"  # Path for updated systems
+else:
+    raise FileNotFoundError(
+        "No valid CA certificate bundle found. Please ensure your system has a CA bundle at either "
+        "/etc/ssl/cert.pem or /usr/local/share/certs/ca-root-nss.crt"
+    )
 
 #
 # Script Start
@@ -484,7 +494,7 @@ for instance_obj in instances_array:
             "Authorization": f"Token {piaToken}",
             "content-type": "application/json"
         }
-        dipSession = CreateRequestsSession(None, piaAuthHeaders, "/etc/ssl/cert.pem")
+        dipSession = CreateRequestsSession(None, piaAuthHeaders, ca_bundle)
         break # Only need one set of details
 
 # Now we process each instance that needs the server changing


### PR DESCRIPTION
This pull request addresses an issue in PIAWireguard.py where the CA bundle path was hardcoded to /etc/ssl/cert.pem, which no longer exists on updated OPNsense systems (e.g., after version 24.7.10_2). The script would fail with the following error:

`OSError: Could not find a suitable TLS CA certificate bundle, invalid path: /etc/ssl/cert.pem`

**Fix**
Introduced fallback logic to dynamically check for the CA bundle path: First, checks for /etc/ssl/cert.pem (used in older systems). Falls back to /usr/local/share/certs/ca-root-nss.crt (used in updated systems). Raises a clear error if no valid CA bundle is found. This ensures compatibility across both older and newer OPNsense systems.