### PR TITLE
Add `-` to the list of valid characters in name pattern

### DIFF
--- a/PIAWireguard.py
+++ b/PIAWireguard.py
@@ -45,7 +45,7 @@ from requests.adapters import HTTPAdapter
 #
 
 def validate_json(data):
-    name_pattern = re.compile(r'^[a-zA-Z0-9_]+$')
+    name_pattern = re.compile(r'^[a-zA-Z0-9_-]+$')
     required_keys = ["opnsenseURL", "opnsenseKey", "opnsenseSecret", "piaUsername", "piaPassword", "opnsenseWGPrefixName", "instances"]
     for key in required_keys:
         if key not in data:


### PR DESCRIPTION
The name_pattern regex doesn't consider `-` to be a valid character when it should be, so add that to the regex characters.

For example:
```
2026-03-10 13:47:35 INFO:US Washington DC | ID: us_washington_dc | Port forwarding: False | Geo-located: False
2026-03-10 13:47:35 INFO:US West Streaming Optimized | ID: us-streaming-2 | Port forwarding: False | Geo-located: False
2026-03-10 13:47:35 INFO:US West Virginia | ID: us_west_virginia-pf | Port forwarding: False | Geo-located: True
```